### PR TITLE
Fixed missing "t" typo - Issue #4

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -175,7 +175,7 @@ The Cypress end-to-end test framework works by controlling the web browser. A te
 
 Cypress component tests work by mounting a Vue Component into a browser and allowing tests to interact with it in isolation from the application.  A typical comonent test will:
   1. Configuring and mounting the component into the test framework.
-  1. Query the component for an _html element_ of interest (e.g. button, ext field)
+  1. Query the component for an _html element_ of interest (e.g. button, text field)
   1. Interact with that element (e.g. click the button, enter some text)
   1. Make an assertion about the result (e.g. the component emits an event or changes state).
 


### PR DESCRIPTION
Changed "ext" to "text" in the ONBOARDING.md file. This was located at the end of bullet point 3 under "Component Tests" in the "Cypress" section of the file.

Closes #4 